### PR TITLE
Merge SP2608: bc2adls 28.57.0 → 28.59.0

### DIFF
--- a/.AL-Go/settings.json
+++ b/.AL-Go/settings.json
@@ -8,5 +8,5 @@
     "businessCentral\\test"
   ],
   "bcptTestFolders": [],
-  "repoVersion": "28.57"
+  "repoVersion": "28.58"
 }

--- a/.AL-Go/settings.json
+++ b/.AL-Go/settings.json
@@ -8,5 +8,5 @@
     "businessCentral\\test"
   ],
   "bcptTestFolders": [],
-  "repoVersion": "28.58"
+  "repoVersion": "28.59"
 }

--- a/businessCentral/app/Translations/Zig365 Insights Connector.g.xlf
+++ b/businessCentral/app/Translations/Zig365 Insights Connector.g.xlf
@@ -148,6 +148,11 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Deleted Record - Field Entry No. - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Table 2785369961 - Field 2231518605 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Primary Key Values</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Deleted Record - Field Primary Key Values - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Table 2785369961 - Field 3076185996 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>System ID</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -513,6 +518,16 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Delivered DateTime - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 2223057862 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies whether the generated CSV file names in Azure Data Lake should be suffixed with _full or _incremental, so that downstream pipelines can differentiate between a full export (first run, or first run after a reset) and an incremental export. Only applies to the Azure Data Lake storage type.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Distinguish Full Incremental - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 2223057862 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Distinguish full and incremental exports</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Distinguish Full Incremental - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Table 4249570476 - Field 2183130790 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies if operational telemetry will be emitted to this extension publisher's telemetry pipeline. You will have to configure a telemetry account for this extension first.</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -628,6 +643,16 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Translations - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 128091690 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies if a certificate will be used for OAuth2 authentication instead of a client secret.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Use Certificate Authentication - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 128091690 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Use Certificate Authentication</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Use Certificate Authentication - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Table 4249570476 - Field 3808103248 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies if the captions of fields will be used instead of names. Be aware that the user of the export in all companies must have the same language.</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -647,6 +672,16 @@
           <source>IDs for Duplicates Only</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Use IDs for Duplicates Only - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 3765130430 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies if the primary key fields of tables should be used as key columns in the Open Mirroring metadata instead of SystemId. Enable this if records are recreated with new SystemIds causing duplicates in the mirrored database.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Use Primary Key for Mirroring - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Table 4249570476 - Field 3765130430 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Use Primary Key for Mirroring</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Setup - Field Use Primary Key for Mirroring - Property Caption</note>
         </trans-unit>
         <trans-unit id="Table 4249570476 - Field 334359692 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies if the captions of Tables will be used instead of names. Be aware that the user of the export in all companies must have the same language.</source>
@@ -692,6 +727,11 @@
           <source>The following fields have been incorrectly enabled for exports in the table %1: %2</source>
           <note from="Developer" annotates="general" priority="2">%1 = table name; %2 = List of invalid field names</note>
           <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Table - NamedType InvalidFieldConfiguredMsg</note>
+        </trans-unit>
+        <trans-unit id="Table 3041034051 - NamedType 146479741" size-unit="char" translate="yes" xml:space="preserve">
+          <source>The following primary key fields of table %1 have an unsupported type and have been skipped from the export: %2. The exported data may be incomplete.</source>
+          <note from="Developer" annotates="general" priority="2">%1 = table name; %2 = list of skipped field names</note>
+          <note from="Xliff Generator" annotates="general" priority="3">Table ADLSE Table - NamedType SkippedPrimaryKeyFieldsMsg</note>
         </trans-unit>
         <trans-unit id="Table 3041034051 - NamedType 2570556267" size-unit="char" translate="yes" xml:space="preserve">
           <source>Session stopped by user.</source>
@@ -1027,6 +1067,11 @@
           <source>Timed out waiting to acquire lease on blob %1 after %2 seconds. %3</source>
           <note from="Developer" annotates="general" priority="2">%1: blob name, %2: total waiting time in seconds, %3: Http Response</note>
           <note from="Xliff Generator" annotates="general" priority="3">Codeunit ADLSE Gen 2 Util - NamedType TimedOutWaitingForLockOnBlobErr</note>
+        </trans-unit>
+        <trans-unit id="Codeunit 582512233 - NamedType 1617041183" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Failed to acquire an access token. Verify the credentials configured in the ADLSE Setup.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Codeunit ADLSE Http - NamedType AcquireTokenFailedErr</note>
         </trans-unit>
         <trans-unit id="Codeunit 582512233 - NamedType 4165240009" size-unit="char" translate="yes" xml:space="preserve">
           <source>There was an error while acquiring the authentication token, error request: %1.</source>
@@ -1513,6 +1558,11 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Page 4249570476 - NamedType 1741368782" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Password set</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - NamedType CertificatePasswordSetLbl</note>
+        </trans-unit>
         <trans-unit id="Page 4249570476 - NamedType 366675938" size-unit="char" translate="yes" xml:space="preserve">
           <source>ID not shown</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -1527,6 +1577,26 @@
           <source>Data from one or more tables failed to export on the last run. Please check the tables below to see the error(s).</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - NamedType ExportFailureNotificationMsg</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - NamedType 4151552178" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Changing this setting requires clearing the exported schema and resetting all tables. All data will be re-exported from scratch on the next run. Do you want to continue?</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - NamedType UsePrimaryKeyForMirroringConfirmQst</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Method 2555594772 - NamedType 76040314" size-unit="char" translate="yes" xml:space="preserve">
+          <source>No certificate (click to upload)</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Method UpdateCertificateStatus - NamedType NoCertificateLbl</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Method 2555594772 - NamedType 2553944727" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Certificate uploaded (click to change)</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Method UpdateCertificateStatus - NamedType CertificateUploadedLbl</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Method 3704836514 - NamedType 3077000456" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Certificate file was not uploaded.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Method UploadCertificate - NamedType FileNotUploadedErr</note>
         </trans-unit>
         <trans-unit id="Page 4249570476 - Control 3266712818 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Data Format</source>
@@ -1548,6 +1618,26 @@
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control Access - Property Caption</note>
         </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 349922534 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies the PFX certificate used for OAuth2 authentication. Click to upload a new certificate file (.pfx or .p12).</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control CertificateUploadStatus - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 349922534 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Certificate</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control CertificateUploadStatus - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 1133333245 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies the password for the PFX certificate.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control ClientCertificatePassword - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 1133333245 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Certificate Password</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control ClientCertificatePassword - Property Caption</note>
+        </trans-unit>
         <trans-unit id="Page 4249570476 - Control 652819368 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
           <source>Specifies the application client ID for the Azure App Registration that accesses the storage account.</source>
           <note from="Developer" annotates="general" priority="2"></note>
@@ -1567,6 +1657,16 @@
           <source>Client secret</source>
           <note from="Developer" annotates="general" priority="2"></note>
           <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control Client secret - Property Caption</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 156530210 - Property 1295455071" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Specifies whether to use a certificate for OAuth2 authentication instead of a client secret.</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control UseCertificateAuthentication - Property ToolTip</note>
+        </trans-unit>
+        <trans-unit id="Page 4249570476 - Control 156530210 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
+          <source>Use Certificate Authentication</source>
+          <note from="Developer" annotates="general" priority="2"></note>
+          <note from="Xliff Generator" annotates="general" priority="3">Page ADLSE Setup - Control UseCertificateAuthentication - Property Caption</note>
         </trans-unit>
         <trans-unit id="Page 4249570476 - Control 1267408499 - Property 2879900210" size-unit="char" translate="yes" xml:space="preserve">
           <source>Azure Data Lake</source>

--- a/businessCentral/app/app.json
+++ b/businessCentral/app/app.json
@@ -4,7 +4,7 @@
   "publisher": "The bc2adls team",
   "brief": "Sync data from Business Central to Microsoft Fabric and Azure storage",
   "description": "Exports data in chosen tables to Microsoft Fabric and Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/Bertverbeek4PS/bc2adls.",
-  "version": "28.57.0.0",
+  "version": "28.58.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://github.com/Bertverbeek4PS/bc2adls?tab=readme-ov-file#introduction",

--- a/businessCentral/app/app.json
+++ b/businessCentral/app/app.json
@@ -4,7 +4,7 @@
   "publisher": "The bc2adls team",
   "brief": "Sync data from Business Central to Microsoft Fabric and Azure storage",
   "description": "Exports data in chosen tables to Microsoft Fabric and Azure Data Lake and keeps it in sync by incremental updates. Before you use this tool, please read the SUPPORT.md file at https://github.com/Bertverbeek4PS/bc2adls.",
-  "version": "28.58.0.0",
+  "version": "28.59.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://github.com/Bertverbeek4PS/bc2adls?tab=readme-ov-file#introduction",

--- a/businessCentral/app/src/CompanySetupTables.Page.al
+++ b/businessCentral/app/src/CompanySetupTables.Page.al
@@ -128,8 +128,9 @@ page 82565 "ADLSE Company Setup Tables"
                 var
                     ADLSETable: Record "ADLSE Table";
                 begin
-                    ADLSETable.Get(Rec."Table ID");
-                    ADLSETable.Delete(true);
+                    Rec.Delete(true);
+                    if ADLSETable.Get(Rec."Table ID") then
+                        ADLSETable.Delete(true);
                     CurrPage.Update();
                 end;
             }

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -381,6 +381,8 @@ codeunit 82561 "ADLSE Execute"
             if EmitTelemetry then
                 ADLSEExecution.Log('ADLSE-041', 'All exports are finished', Verbosity::Normal);
         end;
+
+        OnAfterSetStateFinished(ADLSETable, TableCaption);
     end;
 
     procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
@@ -463,4 +465,8 @@ codeunit 82561 "ADLSE Execute"
         ADLSECommunication.UpdateCdmJsons(EntityJsonNeedsUpdate, ManifestJsonsNeedsUpdate);
     end;
 
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterSetStateFinished(var ADLSETable: Record "ADLSE Table"; TableCaption: Text)
+    begin
+    end;
 }

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -3,7 +3,6 @@
 namespace bc2adls;
 codeunit 82561 "ADLSE Execute"
 {
-    Access = Internal;
     TableNo = "ADLSE Table";
     Permissions = tabledata "ADLSE Table" = rm;
 
@@ -127,7 +126,7 @@ codeunit 82561 "ADLSE Execute"
         ExportTableDeletes(TableID, ADLSECommunicationDeletions, DeletedLastEntryNo, DidUpserts);
     end;
 
-    procedure UpdatedRecordsExist(TableID: Integer; UpdatedLastTimeStamp: BigInteger): Boolean
+    internal procedure UpdatedRecordsExist(TableID: Integer; UpdatedLastTimeStamp: BigInteger): Boolean
     var
         ADLSESeekData: Report "ADLSE Seek Data";
         RecordRef: RecordRef;
@@ -238,7 +237,7 @@ codeunit 82561 "ADLSE Execute"
             ADLSEExecution.Log('ADLSE-009', 'Updated records exported', Verbosity::Normal);
     end;
 
-    procedure DeletedRecordsExist(TableID: Integer; DeletedLastEntryNo: BigInteger): Boolean
+    internal procedure DeletedRecordsExist(TableID: Integer; DeletedLastEntryNo: BigInteger): Boolean
     var
         ADLSEDeletedRecord: Record "ADLSE Deleted Record";
         ADLSESeekData: Report "ADLSE Seek Data";
@@ -308,7 +307,7 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Deleted Record", 'rd')]
-    procedure FixDeletedRecordThatAreInTable(var ADLSEDeletedRecord: Record "ADLSE Deleted Record")
+    internal procedure FixDeletedRecordThatAreInTable(var ADLSEDeletedRecord: Record "ADLSE Deleted Record")
     var
         RecordRef: RecordRef;
     begin
@@ -328,7 +327,7 @@ codeunit 82561 "ADLSE Execute"
     end;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'r')]
-    procedure CreateFieldListForTable(TableID: Integer) FieldIdList: List of [Integer]
+    internal procedure CreateFieldListForTable(TableID: Integer) FieldIdList: List of [Integer]
     var
         ADLSEField: Record "ADLSE Field";
         ADLSEUtil: Codeunit "ADLSE Util";
@@ -385,7 +384,7 @@ codeunit 82561 "ADLSE Execute"
         OnAfterSetStateFinished(ADLSETable, TableCaption);
     end;
 
-    procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
+    internal procedure UpdateInProgressTableTimestamp(var Rec: Record "ADLSE Table"; LastTimestamp: BigInteger; Deletes: Boolean)
     var
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";
         ADLSEExecution: Codeunit "ADLSE Execution";
@@ -422,7 +421,7 @@ codeunit 82561 "ADLSE Execute"
         Commit(); // to save the last time stamps into the database.
     end;
 
-    procedure ExportSchema(tableId: Integer)
+    internal procedure ExportSchema(tableId: Integer)
     var
         ADLSESetup: Record "ADLSE Setup";
         ADLSETableLastTimestamp: Record "ADLSE Table Last Timestamp";

--- a/businessCentral/app/src/Execute.Codeunit.al
+++ b/businessCentral/app/src/Execute.Codeunit.al
@@ -376,6 +376,7 @@ codeunit 82561 "ADLSE Execute"
         if not ADLSECurrentSession.AreAnySessionsActive() then begin
             ADLSESetupRec.GetSingleton();
             ADLSEExternalEvents.OnExportFinished(ADLSESetupRec, ADLSETable);
+            OnExportFinished(ADLSETable, TableCaption);
 
             if EmitTelemetry then
                 ADLSEExecution.Log('ADLSE-041', 'All exports are finished', Verbosity::Normal);
@@ -466,6 +467,11 @@ codeunit 82561 "ADLSE Execute"
 
     [IntegrationEvent(false, false)]
     internal procedure OnAfterSetStateFinished(var ADLSETable: Record "ADLSE Table"; TableCaption: Text)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    internal procedure OnExportFinished(var ADLSETable: Record "ADLSE Table"; TableCaption: Text)
     begin
     end;
 }

--- a/businessCentral/app/src/Setup.Codeunit.al
+++ b/businessCentral/app/src/Setup.Codeunit.al
@@ -112,7 +112,6 @@ codeunit 82560 "ADLSE Setup"
             exit;
         if not ADLSESetup.Exists() then
             exit;
-        ADLSESetup.GetSingleton();
         ADLSESetup."Schema Exported On" := 0DT;
         ADLSESetup.Workspace := '';
         ADLSESetup.Lakehouse := '';

--- a/businessCentral/app/src/Setup.Codeunit.al
+++ b/businessCentral/app/src/Setup.Codeunit.al
@@ -100,6 +100,30 @@ codeunit 82560 "ADLSE Setup"
         ADLSECredentials.Check();
     end;
 
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Setup", 'rm')]
+    [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Current Session", 'd')]
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::System.DataAdministration."Environment Cleanup", OnClearDatabaseConfig, '', false, false)]
+    local procedure EnvironmentCleanup_OnClearDatabaseConfig(SourceEnv: Enum System.DataAdministration."Environment Type"; DestinationEnv: Enum System.DataAdministration."Environment Type")
+    var
+        ADLSESetup: Record "ADLSE Setup";
+        ADLSECurrentSession: Record "ADLSE Current Session";
+    begin
+        if DestinationEnv <> DestinationEnv::Sandbox then
+            exit;
+        if not ADLSESetup.Exists() then
+            exit;
+        ADLSESetup.GetSingleton();
+        ADLSESetup."Schema Exported On" := 0DT;
+        ADLSESetup.Workspace := '';
+        ADLSESetup.Lakehouse := '';
+        ADLSESetup.LandingZone := '';
+        ADLSESetup.Container := '';
+        ADLSESetup."Account Name" := '';
+        ADLSESetup.Modify(false);
+        ADLSECurrentSession.DeleteAll(true);
+    end;
+
+
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Field", 'rd')]
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Table", 'rd')]
     [InherentPermissions(PermissionObjectType::TableData, Database::"ADLSE Setup", 'm')]

--- a/businessCentral/app/src/Table.Table.al
+++ b/businessCentral/app/src/Table.Table.al
@@ -246,10 +246,6 @@ table 82561 "ADLSE Table"
     begin
         if Rec.FindSet(true) then
             repeat
-                if not Rec.Enabled then begin
-                    Rec.Enabled := true;
-                    Rec.Modify(true);
-                end;
                 ADLSESetup.GetSingleton();
 
                 if not AllCompanies then begin
@@ -277,8 +273,6 @@ table 82561 "ADLSE Table"
 
                 if (ADLSESetup."Delete Table") then
                     ADLSECommunication.ResetTableExport(Rec."Table ID", AllCompanies);
-
-                Rec.Modify(true);
 
                 OnAfterResetSelected(Rec);
 

--- a/businessCentral/test/app.json
+++ b/businessCentral/test/app.json
@@ -2,7 +2,7 @@
   "id": "03486619-1622-4261-ae0e-b366b3c96e3c",
   "name": "Azure Data Lake Storage Export Tests",
   "publisher": "The bc2adls team",
-  "version": "28.57.0.0",
+  "version": "28.58.0.0",
   "brief": "Tests for Azure Data Lake Storage Export",
   "description": "Tests for Azure Data Lake Storage Export",
   "privacyStatement": "",
@@ -46,7 +46,7 @@
       "publisher": "The bc2adls team",
       "name": "Azure Data Lake Storage Export",
       "id": "1688530c-452c-4b06-8947-ab4bf5b26053",
-      "version": "28.57.0.0"
+      "version": "28.58.0.0"
     }
   ],
   "screenshots": [],

--- a/businessCentral/test/app.json
+++ b/businessCentral/test/app.json
@@ -2,7 +2,7 @@
   "id": "03486619-1622-4261-ae0e-b366b3c96e3c",
   "name": "Azure Data Lake Storage Export Tests",
   "publisher": "The bc2adls team",
-  "version": "28.58.0.0",
+  "version": "28.59.0.0",
   "brief": "Tests for Azure Data Lake Storage Export",
   "description": "Tests for Azure Data Lake Storage Export",
   "privacyStatement": "",
@@ -46,7 +46,7 @@
       "publisher": "The bc2adls team",
       "name": "Azure Data Lake Storage Export",
       "id": "1688530c-452c-4b06-8947-ab4bf5b26053",
-      "version": "28.58.0.0"
+      "version": "28.59.0.0"
     }
   ],
   "screenshots": [],

--- a/businessCentral/test/app.json
+++ b/businessCentral/test/app.json
@@ -43,10 +43,10 @@
       "version": "27.0.0.0"
     },
     {
-      "publisher": "The bc2adls team",
-      "name": "Azure Data Lake Storage Export",
-      "id": "1688530c-452c-4b06-8947-ab4bf5b26053",
-      "version": "28.57.0.0"
+      "publisher": "Zig",
+      "name": "Zig365 Insights Connector",
+      "id": "f50ed17c-be40-4d00-ad13-2e5132038664",
+      "version": "28.59.0.0"
     }
   ],
   "screenshots": [],


### PR DESCRIPTION
## Upstream sync: 28.57.0 → 28.59.0

Merges the `original` branch (synced to upstream tag `28.59.0`) into `main`.

### Changes from upstream (14 commits)

**28.58.0**
- Fix: table reset no longer re-enables disabled tables (#531)
- Fix: delete tables from multi-company config screen (#536)
- Clear setup after copy to Sandbox (#539)
- Add `OnAfterSetStateFinished` event and change access to internal in `Execute.Codeunit`

**28.59.0**
- Add `OnExportFinished` event in `ADLSE Execute` (#546)

### Files changed
- `businessCentral/app/app.json` — version bump
- `businessCentral/test/app.json` — version bump
- `.AL-Go/settings.json` — version bump
- `Execute.Codeunit.al` — new events
- `Setup.Codeunit.al` — clear setup on sandbox copy
- `Table.Table.al` — table reset fix
- `CompanySetupTables.Page.al` — delete tables fix

> ⚠️ Please use **Merge pull request** (not squash) to preserve history.